### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: LaraDashboard CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/laradashboard/laradashboard/security/code-scanning/1](https://github.com/laradashboard/laradashboard/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow does not perform any write operations on the repository, we can set `contents: read` at the root level of the workflow. This ensures that all jobs in the workflow inherit read-only permissions for the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
