### PR TITLE
fix: module replace always activates and release force=1 for Laravel 12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
             -H "Accept: application/json" \
             -F "version=${{ needs.detect-version.outputs.version }}" \
             -F "github_tag=${{ needs.detect-version.outputs.tag }}" \
-            -F "force=true" \
+            -F "force=1" \
             -F "zip=@${ZIP_FILE}"
 
   upgrade-demo:

--- a/app/Services/Modules/ModuleService.php
+++ b/app/Services/Modules/ModuleService.php
@@ -529,18 +529,13 @@ class ModuleService
         // This is handled automatically by setModuleStatus() which cleans up duplicates
 
         // Install the new module
-        $installedModuleName = $this->installModuleFromTemp($tempPath, $folderName, $moduleName);
+        $this->installModuleFromTemp($tempPath, $folderName, $moduleName);
 
-        // Re-enable if was previously enabled
-        if ($wasEnabled) {
-            try {
-                $this->toggleModule($installedModuleName, true);
-            } catch (\Throwable $e) {
-                Log::warning("Could not re-enable module after replacement: " . $e->getMessage());
-            }
-        }
+        // Replacing is an intentional upgrade — always activate so the module is usable immediately.
+        $jsonName = $this->getModuleJsonName($moduleName) ?? $moduleName;
+        $this->activateModuleAfterInstall($jsonName);
 
-        return $installedModuleName;
+        return $this->normalizeModuleName($jsonName);
     }
 
     /**
@@ -574,6 +569,9 @@ class ModuleService
             File::moveDirectory($extractedPath, $targetPath);
             File::deleteDirectory($tempPath);
         }
+
+        // Refresh nwidart's in-memory module registry so the new files are discoverable.
+        $this->refreshModuleRegistry();
 
         // Save this module to the modules_statuses.json file as DISABLED.
         // New modules are disabled by default for security - admin must explicitly enable them.
@@ -771,6 +769,26 @@ class ModuleService
         return Str::studly(basename($modulePath));
     }
 
+    /**
+     * Clear nwidart's cached module scan results.
+     *
+     * Required after upload/replace — otherwise module:enable may target stale paths.
+     */
+    public function refreshModuleRegistry(): void
+    {
+        app('modules')->resetModules();
+    }
+
+    /**
+     * Enable a module that was just installed or replaced on disk.
+     */
+    public function activateModuleAfterInstall(string $moduleName): void
+    {
+        $jsonName = $this->getModuleJsonName($moduleName) ?? $moduleName;
+        $this->refreshModuleRegistry();
+        $this->toggleModule($jsonName, true);
+    }
+
     public function toggleModule($moduleName, $enable = true, bool $skipMigrations = false): bool
     {
         $action = $enable ? 'enable' : 'disable';
@@ -778,6 +796,8 @@ class ModuleService
             'user_id' => Auth::id(),
             'ip' => request()->ip(),
         ]);
+
+        $this->refreshModuleRegistry();
 
         // Fire action hooks before enabling/disabling
         if ($enable) {

--- a/tests/Feature/Modules/ModuleReplaceActivationTest.php
+++ b/tests/Feature/Modules/ModuleReplaceActivationTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Modules\ModuleService;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    $this->moduleService = app(ModuleService::class);
+    $this->studlyName = 'ReplaceActivateTest';
+    $this->slugName = 'replaceactivatetest';
+    $this->modulePath = base_path('modules/' . $this->slugName);
+    $this->statusFile = base_path('modules_statuses.json');
+    $this->originalStatuses = File::exists($this->statusFile)
+        ? File::get($this->statusFile)
+        : null;
+
+    foreach ([$this->modulePath, base_path('modules/' . $this->studlyName)] as $path) {
+        if (File::isDirectory($path)) {
+            File::deleteDirectory($path);
+        }
+    }
+
+    $this->artisan('module:make', ['name' => [$this->studlyName]])->assertSuccessful();
+});
+
+afterEach(function () {
+    foreach ([$this->modulePath, base_path('modules/' . $this->studlyName)] as $path) {
+        if (File::isDirectory($path)) {
+            File::deleteDirectory($path);
+        }
+    }
+
+    if ($this->originalStatuses !== null) {
+        File::put($this->statusFile, $this->originalStatuses);
+    }
+});
+
+test('replace module activates the module even when it was previously disabled', function () {
+    $this->moduleService->setModuleStatus($this->slugName, false);
+
+    $tempPath = storage_path('app/modules_temp/replace_test_' . uniqid('', true));
+    File::ensureDirectoryExists($tempPath);
+
+    $replacementPath = $tempPath . '/' . $this->studlyName;
+    File::copyDirectory($this->modulePath, $replacementPath);
+
+    $moduleJsonPath = $replacementPath . '/module.json';
+    $moduleJson = json_decode(File::get($moduleJsonPath), true, 512, JSON_THROW_ON_ERROR);
+    $moduleJson['version'] = '9.9.9';
+    File::put($moduleJsonPath, json_encode($moduleJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+    $this->moduleService->replaceModule($tempPath, $this->slugName);
+
+    $statuses = $this->moduleService->getModuleStatuses();
+
+    expect($statuses[$this->slugName])->toBeTrue();
+    expect(File::exists($this->modulePath . '/module.json'))->toBeTrue();
+
+    $installedJson = json_decode(File::get($this->modulePath . '/module.json'), true, 512, JSON_THROW_ON_ERROR);
+    expect($installedJson['version'])->toBe('9.9.9');
+});
+
+test('replace module refreshes nwidart registry before activation', function () {
+    $this->moduleService->setModuleStatus($this->slugName, true);
+
+    $tempPath = storage_path('app/modules_temp/replace_test_' . uniqid('', true));
+    File::ensureDirectoryExists($tempPath);
+
+    $replacementPath = $tempPath . '/' . $this->studlyName;
+    File::copyDirectory($this->modulePath, $replacementPath);
+
+    $moduleJsonPath = $replacementPath . '/module.json';
+    $moduleJson = json_decode(File::get($moduleJsonPath), true, 512, JSON_THROW_ON_ERROR);
+    $moduleJson['version'] = '8.8.8';
+    File::put($moduleJsonPath, json_encode($moduleJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+    app('modules')->resetModules();
+
+    $this->moduleService->replaceModule($tempPath, Str::studly($this->slugName));
+
+    expect($this->moduleService->getModuleStatuses()[$this->slugName])->toBeTrue();
+});


### PR DESCRIPTION
Always activate modules after replace by refreshing nwidart registry. Send force=1 in release workflow — Laravel 12 rejects string "true".